### PR TITLE
Invoke autocomplete from middle of statement

### DIFF
--- a/Gauge.VisualStudio/Autocomplete/AutoCompleteCommandFilter.cs
+++ b/Gauge.VisualStudio/Autocomplete/AutoCompleteCommandFilter.cs
@@ -54,9 +54,9 @@ namespace Gauge.VisualStudio.AutoComplete
                         break;
                     case VSConstants.VSStd2KCmdID.TYPECHAR:
                         var lineText = TextView.Caret.Position.BufferPosition.GetContainingLine().GetText().Trim();
-                        var stepRegex = new Regex(@"^(\*\s?\w*)$", RegexOptions.Compiled);
+                        var stepRegex = new Regex(@"^(\*\s?\w*).*$", RegexOptions.Compiled);
                         //the current character isn't yet available in the buffer!, add it to the text to check
-                        if (stepRegex.IsMatch(string.Format("{0}{1}", GetTypeChar(pvaIn), lineText)))
+                        if (stepRegex.IsMatch(string.Format("{0}{1}", lineText, GetTypeChar(pvaIn))))
                         {
                             StartSession();
                         }


### PR DESCRIPTION
This solves the issue https://github.com/getgauge/gauge-visualstudio/issues/32

PS:- There was a bug that adds the newly typed character at the beginning of the sentence instead of the end.

Also modified the regex so that it will take the entire sentence even if it contains special characters(previously it breaks at the 'blank space')
If we are not supporting special characters we can use the regex ^(\*\s?\w*)(\s\w*)*$