### PR TITLE
Issues/112 no tests vs2015 2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/Gauge.ItemTemplate.Concept/Gauge.ItemTemplate.Concept.csproj
+++ b/Gauge.ItemTemplate.Concept/Gauge.ItemTemplate.Concept.csproj
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>12.0</OldToolsVersion>
-    <UpgradeBackupLocation />
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/Gauge.ItemTemplate.Spec/Gauge.ItemTemplate.Spec.csproj
+++ b/Gauge.ItemTemplate.Spec/Gauge.ItemTemplate.Spec.csproj
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>12.0</OldToolsVersion>
-    <UpgradeBackupLocation />
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/Gauge.ProjectTemplates.Basic/Gauge.ProjectTemplates.Basic.csproj
+++ b/Gauge.ProjectTemplates.Basic/Gauge.ProjectTemplates.Basic.csproj
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>12.0</OldToolsVersion>
-    <UpgradeBackupLocation />
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -68,7 +69,9 @@
     <None Include="StepImplementation.cs" />
     <None Include="Env\default\default.properties" />
     <None Include="manifest.json" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Specs\example.spec" />
   </ItemGroup>
   <ItemGroup>

--- a/Gauge.ProjectTemplates.Basic/packages.config
+++ b/Gauge.ProjectTemplates.Basic/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="3.5.0" targetFramework="net45" />
-  <package id="Gauge.CSharp.Lib" version="$gaugelibversion$" targetFramework="net45" />
+  <package id="Gauge.CSharp.Lib" version="0.4.0" targetFramework="net45" />
 </packages>

--- a/Gauge.ProjectTemplates.Webdriver/Gauge.ProjectTemplates.Webdriver.csproj
+++ b/Gauge.ProjectTemplates.Webdriver/Gauge.ProjectTemplates.Webdriver.csproj
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>12.0</OldToolsVersion>
-    <UpgradeBackupLocation />
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>

--- a/Gauge.ProjectTemplates.Webdriver/packages.config
+++ b/Gauge.ProjectTemplates.Webdriver/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="3.5.0" targetFramework="net45" />
-  <package id="Gauge.CSharp.Lib" version="$gaugelibversion$" targetFramework="net45" />
+  <package id="Gauge.CSharp.Lib" version="0.4.0" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="2.53.0" targetFramework="net45" />
 </packages>

--- a/Gauge.VisualStudio.Core/Gauge.VisualStudio.Core.csproj
+++ b/Gauge.VisualStudio.Core/Gauge.VisualStudio.Core.csproj
@@ -65,7 +65,8 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Condition="$(VisualStudioVersion) == '12.0'" Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+	<Reference Condition="$(VisualStudioVersion) == '14.0'" Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.10.0.30319\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
       <Private>False</Private>

--- a/Gauge.VisualStudio.Core/Gauge.VisualStudio.Core.csproj
+++ b/Gauge.VisualStudio.Core/Gauge.VisualStudio.Core.csproj
@@ -65,8 +65,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Condition="$(VisualStudioVersion) == '12.0'" Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-	<Reference Condition="$(VisualStudioVersion) == '14.0'" Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Condition="$(VisualStudioVersion) == '14.0'" Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.10.0.30319\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
       <Private>False</Private>

--- a/Gauge.VisualStudio.Core/Helpers/DTEHelper.cs
+++ b/Gauge.VisualStudio.Core/Helpers/DTEHelper.cs
@@ -29,18 +29,14 @@ namespace Gauge.VisualStudio.Core.Helpers
 {
     public static class DTEHelper
     {
-        private static readonly string[] testRunners = {"vstest.executionengine.x86", "te.processhost.managed"};
+        private static readonly string[] TestRunners = {"vstest.executionengine.x86", "te.processhost.managed"};
         public static DTE GetCurrent()
         {
             var testRunnerProcess = Process.GetCurrentProcess();
-            if (!testRunners.Contains(testRunnerProcess.ProcessName.ToLower()))
+            if (!TestRunners.Contains(testRunnerProcess.ProcessName.ToLower()))
                 throw new Exception("Test Runner Process not expected: " + testRunnerProcess.ProcessName.ToLower());
 
-            var progId = $"!VisualStudio.DTE.12.0:{GetVisualStudioProcessId(testRunnerProcess.Id)}";
-
-#if DEBUG
-            progId = $"!VisualStudio.DTE.14.0:{GetVisualStudioProcessId(testRunnerProcess.Id)}";
-#endif
+            var progId = $"!VisualStudio.DTE.14.0:{GetVisualStudioProcessId(testRunnerProcess.Id)}";
 
             object runningObject = null;
 

--- a/Gauge.VisualStudio.Core/Helpers/DTEHelper.cs
+++ b/Gauge.VisualStudio.Core/Helpers/DTEHelper.cs
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Management;
 using System.Runtime.InteropServices;
 using EnvDTE;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
 using Process = System.Diagnostics.Process;
 using Thread = System.Threading.Thread;
 
@@ -25,13 +29,18 @@ namespace Gauge.VisualStudio.Core.Helpers
 {
     public static class DTEHelper
     {
+        private static readonly string[] testRunners = {"vstest.executionengine.x86", "te.processhost.managed"};
         public static DTE GetCurrent()
         {
             var testRunnerProcess = Process.GetCurrentProcess();
-            if (!"vstest.executionengine.x86".Equals(testRunnerProcess.ProcessName, StringComparison.OrdinalIgnoreCase))
-                return null;
+            if (!testRunners.Contains(testRunnerProcess.ProcessName.ToLower()))
+                throw new Exception("Test Runner Process not expected: " + testRunnerProcess.ProcessName.ToLower());
 
-            var progId = string.Format("!{0}.DTE.{1}:{2}", "VisualStudio", "12.0", GetVisualStudioProcessId(testRunnerProcess.Id));
+            var progId = $"!VisualStudio.DTE.12.0:{GetVisualStudioProcessId(testRunnerProcess.Id)}";
+
+#if DEBUG
+            progId = $"!VisualStudio.DTE.14.0:{GetVisualStudioProcessId(testRunnerProcess.Id)}";
+#endif
 
             object runningObject = null;
 

--- a/Gauge.VisualStudio.Core/packages.config
+++ b/Gauge.VisualStudio.Core/packages.config
@@ -3,6 +3,21 @@
   <package id="Gauge.CSharp.Core" version="0.0.2.0" targetFramework="net452" />
   <package id="Gauge.CSharp.Lib" version="0.5.2.0" targetFramework="net452" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.Imaging" version="14.2.25123" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.14.0" version="14.2.25123" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="11.0.50727" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.12.0" version="12.0.21003" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.14.0" version="14.2.25123" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Threading" version="14.1.111" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Utilities" version="14.2.25123" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net45" />
   <package id="VSSDK.DTE" version="7.0.4" targetFramework="net452" />
   <package id="VSSDK.GraphModel" version="11.0.4" targetFramework="net452" />
   <package id="VSSDK.IDE" version="7.0.4" targetFramework="net452" />
@@ -12,7 +27,6 @@
   <package id="VSSDK.IDE.8" version="8.0.4" targetFramework="net452" />
   <package id="VSSDK.IDE.9" version="9.0.4" targetFramework="net452" />
   <package id="VSSDK.OLE.Interop" version="7.0.4" targetFramework="net452" />
-  <package id="VSSDK.Shell.12" version="12.0.4" targetFramework="net452" />
   <package id="VSSDK.Shell.Immutable.10" version="10.0.4" targetFramework="net452" />
   <package id="VSSDK.Shell.Immutable.11" version="11.0.4" targetFramework="net452" />
   <package id="VSSDK.Shell.Immutable.12" version="12.0.4" targetFramework="net452" />

--- a/Gauge.VisualStudio.Model.Tests/Gauge.VisualStudio.Model.Tests.csproj
+++ b/Gauge.VisualStudio.Model.Tests/Gauge.VisualStudio.Model.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Gauge.VisualStudio.licenseheader" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/Gauge.VisualStudio.Model.Tests/app.config
+++ b/Gauge.VisualStudio.Model.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Gauge.VisualStudio.TestAdapter/Gauge.VisualStudio.TestAdapter.csproj
+++ b/Gauge.VisualStudio.TestAdapter/Gauge.VisualStudio.TestAdapter.csproj
@@ -125,20 +125,20 @@
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestWindow">
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestWindow.Core">
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Core.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestWindow.Interfaces">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestWindow.Interfaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UIAutomationTypes" />

--- a/Gauge.VisualStudio.sln
+++ b/Gauge.VisualStudio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gauge.VisualStudio", "Gauge.VisualStudio\Gauge.VisualStudio.csproj", "{DC3355B9-8179-48A6-9A01-0E96F2FB842E}"
 EndProject

--- a/Gauge.VisualStudio/Gauge.VisualStudio.csproj
+++ b/Gauge.VisualStudio/Gauge.VisualStudio.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>

--- a/build.ps1
+++ b/build.ps1
@@ -19,4 +19,4 @@ if($env:MSBUILD_VERBOSITY)
   $verbosity = $env:MSBUILD_VERBOSITY
 }
 
-&$msbuild $sln /m /nologo "/p:configuration=release;OutDir=$($outputPath);VisualStudioVersion=12.0" /t:rebuild /verbosity:$($verbosity)
+&$msbuild $sln /m /nologo "/p:configuration=release;OutDir=$($outputPath);VisualStudioVersion=14.0" /t:rebuild /verbosity:$($verbosity)


### PR DESCRIPTION
FIxed test discovery(#112) in vs2015 and test debugging(#105) in vs2015. In order to support visual studio 2015 I have had to upgrade the solution to vs2015. The solution can no longer be opened in 2013 but the plugin works in both.