### PR TITLE
performance improvements, #134 #151 #170 #206

### DIFF
--- a/Gauge.VisualStudio.Core/Extensions/DocumentExtensions.cs
+++ b/Gauge.VisualStudio.Core/Extensions/DocumentExtensions.cs
@@ -25,9 +25,19 @@ namespace Gauge.VisualStudio.Core.Extensions
             return document.FullName.IsGaugeSpecFile();
         }
 
+        public static bool IsGaugeConceptFile(this Document document)
+        {
+            return document.FullName.IsGaugeConceptFile();
+        }
+
         public static bool IsGaugeSpecFile(this string filePath)
         {
-            return File.Exists(filePath) && new[] {".spec", ".cpt", ".md"}.Any(filePath.EndsWith);
+            return File.Exists(filePath) && new[] {".spec", ".md"}.Any(filePath.EndsWith);
+        }
+
+        public static bool IsGaugeConceptFile(this string filePath)
+        {
+            return File.Exists(filePath) && new[] {".cpt"}.Any(filePath.EndsWith);
         }
     }
 }

--- a/Gauge.VisualStudio.Model/Project.cs
+++ b/Gauge.VisualStudio.Model/Project.cs
@@ -52,7 +52,13 @@ namespace Gauge.VisualStudio.Model
 
             _projectItemsEvents = _events2.ProjectItemsEvents;
             _documentEvents = _events2.DocumentEvents;
-            _documentEvents.DocumentSaved += document => RefreshImplementations(document.ProjectItem);
+            _documentEvents.DocumentSaved += document =>
+            {
+                if (document.IsGaugeConceptFile())
+                {
+                    RefreshImplementations(document.ProjectItem);
+                }
+            };
             _projectItemsEvents.ItemAdded += RefreshImplementations;
             _projectItemsEvents.ItemRemoved += RefreshImplementations;
             _projectItemsEvents.ItemRenamed += (item, name) => RefreshImplementations(item);

--- a/Gauge.VisualStudio/Highlighting/StepTaggerProvider.cs
+++ b/Gauge.VisualStudio/Highlighting/StepTaggerProvider.cs
@@ -17,6 +17,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using EnvDTE;
 using EnvDTE80;
+using Gauge.VisualStudio.Core.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
@@ -57,7 +58,13 @@ namespace Gauge.VisualStudio.Highlighting
             _projectItemsEvents.ItemRemoved += item => RefreshUsages();
             _projectItemsEvents.ItemRenamed += (item, name) => RefreshUsages();
 
-            _documentEvents.DocumentSaved += document => RefreshUsages();
+            _documentEvents.DocumentSaved += document =>
+            {
+                if (document.IsGaugeConceptFile())
+                {
+                    RefreshUsages();
+                }
+            };
         }
 
         public ITagger<T> CreateTagger<T>(ITextView textView, ITextBuffer buffer) where T : ITag


### PR DESCRIPTION
watch for filetype on document save

test discoverer need not listen to build events, test explorer does this already

addresses #134 #151 #170 #206